### PR TITLE
Fixed search for users in non-English speaking countries

### DIFF
--- a/mopidy_youtube/backend.py
+++ b/mopidy_youtube/backend.py
@@ -127,9 +127,10 @@ class YouTubeLibraryProvider(backend.LibraryProvider):
                 logger.debug("Searching YouTube for query '%s'", search_query)
 
                 try:
-                    r = requests.get("https://www.youtube.com/results", params={"search_query": search_query})
+                    headers = {"Accept-Language": "en-US,en;q=0.5"}
+                    r = requests.get("https://www.youtube.com/results", params={"search_query": search_query}, headers=headers)
                     logger.debug(r.text)
-                    regex = r'<a href="/watch\?v=(?P<id>.{11})" class=".*?" data-sessionlink=".*?"  title="(?P<title>.+?)" .+?Duration: (?:(?P<durationHours>[0-9]+):)?(?P<durationMinutes>[0-9]+):(?P<durationSeconds>[0-9]{2}).</span>.*?<a href="(?P<uploaderUrl>/(?:user|channel)/[^"]+)"[^>]+>(?P<uploader>.*?)</a>.*?<div class="yt-lockup-description[^>]*>(?P<description>.*?)</div>'
+                    regex = r'<a href="/watch\?v=(?P<id>.{11})" class=".*?" data-sessionlink=".*?"  title="(?P<title>.+?)" .+?Duration: (?:(?P<durationHours>[0-9]+):)?(?P<durationMinutes>[0-9]+):(?P<durationSeconds>[0-9]{2}).?</span>.*?<a href="(?P<uploaderUrl>/(?:user|channel)/[^"]+)"[^>]+>(?P<uploader>.*?)</a>.*?<div class="yt-lockup-description[^>]*>(?P<description>.*?)</div>'
                     trackList = []
                     for match in re.finditer(regex, r.text):
                         length = int(match.group('durationSeconds')) * 1000


### PR DESCRIPTION
Your fork seems to be the current version of mopidy-youtube right now, but it didn't quite work for me. As I live in Germany, the search results came back with _"Duration: xx:xx:xx "_ replaced by it's German equivalent _"Dauer: xx:xx:xx"_, which broke the search. Also note the randomly missing space in the German version.